### PR TITLE
Adds tests for OrderedQueryables

### DIFF
--- a/QueryableInterceptors.ExceptionWrapping.Test/OrderedTest.cs
+++ b/QueryableInterceptors.ExceptionWrapping.Test/OrderedTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using NUnit.Framework;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace QueryableInterceptors.ExceptionWrapping.Test
+{
+    [TestFixture]
+    public class OrderedTest
+    {
+        IQueryable<object> _items;
+        [SetUp]
+        public void Setup()
+        {
+            _items = Enumerable.Empty<object>()
+                        .AsQueryable()
+                        .WrapExceptions()
+                        .OfType<Exception>()
+                        .With<Exception>();
+        }
+
+        [Test]
+        public void OrderByOnInterceptedQueryable()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var result = _items.OrderBy(s => s.GetHashCode());
+            });
+        }
+    }
+}

--- a/QueryableInterceptors.ExceptionWrapping.Test/Properties/AssemblyInfo.cs
+++ b/QueryableInterceptors.ExceptionWrapping.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("QueryableInterceptors.ExceptionWrapping.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("QueryableInterceptors.ExceptionWrapping.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("359acbce-e590-4574-b872-19e90d26fde9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/QueryableInterceptors.ExceptionWrapping.Test/QueryableInterceptors.ExceptionWrapping.Test.csproj
+++ b/QueryableInterceptors.ExceptionWrapping.Test/QueryableInterceptors.ExceptionWrapping.Test.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{359ACBCE-E590-4574-B872-19E90D26FDE9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>QueryableInterceptors.ExceptionWrapping.Test</RootNamespace>
+    <AssemblyName>QueryableInterceptors.ExceptionWrapping.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="OrderedTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\QueryableInterceptors.ExceptionWrapping\QueryableInterceptors.ExceptionWrapping.csproj">
+      <Project>{17c9a3bb-8896-4853-8ea2-4ee2f1e0f5c3}</Project>
+      <Name>QueryableInterceptors.ExceptionWrapping</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/QueryableInterceptors.ExceptionWrapping.Test/packages.config
+++ b/QueryableInterceptors.ExceptionWrapping.Test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>

--- a/QueryableInterceptors.sln
+++ b/QueryableInterceptors.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryableInterceptors", "QueryableInterceptors\QueryableInterceptors.csproj", "{8B04B578-3968-48E8-8BA9-097666169C35}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C616E676-14A5-4B21-8E9F-A7FA9E0D3714}"
@@ -11,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C616E6
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryableInterceptors.ExceptionWrapping", "QueryableInterceptors.ExceptionWrapping\QueryableInterceptors.ExceptionWrapping.csproj", "{17C9A3BB-8896-4853-8EA2-4EE2F1E0F5C3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryableInterceptors.ExceptionWrapping.Test", "QueryableInterceptors.ExceptionWrapping.Test\QueryableInterceptors.ExceptionWrapping.Test.csproj", "{359ACBCE-E590-4574-B872-19E90D26FDE9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +30,10 @@ Global
 		{17C9A3BB-8896-4853-8EA2-4EE2F1E0F5C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17C9A3BB-8896-4853-8EA2-4EE2F1E0F5C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17C9A3BB-8896-4853-8EA2-4EE2F1E0F5C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{359ACBCE-E590-4574-B872-19E90D26FDE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{359ACBCE-E590-4574-B872-19E90D26FDE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{359ACBCE-E590-4574-B872-19E90D26FDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{359ACBCE-E590-4574-B872-19E90D26FDE9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A simple test case that tests if ordered by is callable on the queryable.
Queryables will throw unable to cast exceptions if it is not supported

Changing the interface of InterceptingQuery from IQueryable<TElement> to IOrderedQueryable<TElement> causes this test to pass (and referencing the project in the solution rather than the nuget one).

I haven't changed that because I'm not sure if there are oddities with that?. It may break existing implementations?.
#1
